### PR TITLE
Enable secure processing and disallow external DTDs

### DIFF
--- a/update/org.eclipse.update.configurator/src/org/eclipse/update/internal/configurator/ConfigurationParser.java
+++ b/update/org.eclipse.update.configurator/src/org/eclipse/update/internal/configurator/ConfigurationParser.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.StringTokenizer;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
@@ -60,6 +61,11 @@ public class ConfigurationParser extends DefaultHandler implements IConfiguratio
 
 		try {
 			parserFactory.setNamespaceAware(true);
+			parserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+			parserFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+			parserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+			parserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+
 			this.parser = parserFactory.newSAXParser();
 		} catch (ParserConfigurationException e) {
 			Utils.log(Utils.newStatus("ConfigurationParser", e)); //$NON-NLS-1$

--- a/update/org.eclipse.update.configurator/src/org/eclipse/update/internal/configurator/FeatureParser.java
+++ b/update/org.eclipse.update.configurator/src/org/eclipse/update/internal/configurator/FeatureParser.java
@@ -17,6 +17,7 @@ package org.eclipse.update.internal.configurator;
 import java.io.*;
 import java.net.*;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.*;
 
 import org.eclipse.osgi.util.NLS;
@@ -45,6 +46,11 @@ public class FeatureParser extends DefaultHandler {
 		super();
 		try {
 			parserFactory.setNamespaceAware(true);
+			parserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+			parserFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+			parserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+			parserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+
 			this.parser = parserFactory.newSAXParser();
 		} catch (ParserConfigurationException e) {
 			System.out.println(e);

--- a/update/org.eclipse.update.configurator/src/org/eclipse/update/internal/configurator/PluginParser.java
+++ b/update/org.eclipse.update.configurator/src/org/eclipse/update/internal/configurator/PluginParser.java
@@ -16,6 +16,7 @@ package org.eclipse.update.internal.configurator;
 
 import java.io.*;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.*;
 
 import org.eclipse.osgi.util.NLS;
@@ -49,6 +50,11 @@ public class PluginParser extends DefaultHandler implements IConfigurationConsta
 		super();
 		try {
 			parserFactory.setNamespaceAware(true);
+			parserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+			parserFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+			parserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+			parserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+
 			this.parser = parserFactory.newSAXParser();
 		} catch (ParserConfigurationException e) {
 			System.out.println(e);


### PR DESCRIPTION
It's good security practice to enable secure processing for DocumentBuilderFactory instances and to disallow external DTDs.